### PR TITLE
Adjust ptrace_scope in a pre-swarm startup set.

### DIFF
--- a/Dockerfile.ssh
+++ b/Dockerfile.ssh
@@ -43,7 +43,7 @@ RUN yum -y update && \
 # - libevent
 # ------------------------------------------------------------
 RUN mkdir -p /opt/hpc/local/build
-ADD src /opt/hpc/local/src
+COPY src /opt/hpc/local/src
 
 ARG LIBEVENT_INSTALL_PATH=/opt/hpc/local/libevent
 ENV LIBEVENT_INSTALL_PATH=$LIBEVENT_INSTALL_PATH


### PR DESCRIPTION
This value will persist across all containers, so there is no need
to run the swarm in privileged mode which provides a bit more protection.

Resource: https://www.kernel.org/doc/Documentation/security/Yama.txt